### PR TITLE
PHPCS fixes

### DIFF
--- a/mathjax-latex-admin.php
+++ b/mathjax-latex-admin.php
@@ -75,8 +75,8 @@ class MathJax_Latex_Admin {
 			''
 		);
 
-		$selected_inline  = get_option( 'kblog_mathjax_latex_inline' ) == 'inline' ? 'selected="true"' : '';
-		$selected_display = get_option( 'kblog_mathjax_latex_inline' ) == 'display' ? 'selected="true"' : '';
+		$selected_inline  = get_option( 'kblog_mathjax_latex_inline' ) === 'inline' ? 'selected="true"' : '';
+		$selected_display = get_option( 'kblog_mathjax_latex_inline' ) === 'display' ? 'selected="true"' : '';
 
 		$syntax_input = <<<EOT
 <select name="kblog_mathjax_latex_inline" id="kblog_mathjax_latex_inline">

--- a/mathjax-latex-admin.php
+++ b/mathjax-latex-admin.php
@@ -226,7 +226,6 @@ EOT;
 				</tr>
 <?php
 	}
-
 } // class
 
 function mathjax_latex_admin_init() {

--- a/mathjax-latex-admin.php
+++ b/mathjax-latex-admin.php
@@ -105,9 +105,7 @@ EOT;
 		$use_cdn = get_option( 'kblog_mathjax_use_cdn', true ) ? 'checked="true"' : '';
 
 		$this->admin_table_row( 'Use MathJax CDN Service?',
-			'Allows use of the MathJax hosted content delivery network.  ' .
-			'By using this, you are agreeing to the ' .
-			'<a href="http://www.mathjax.org/download/mathjax-cdn-terms-of-service/">MathJax CDN Terms of Service</a>.',
+			'Allows use of the MathJax hosted content delivery network. By using this, you are agreeing to the  <a href="http://www.mathjax.org/download/mathjax-cdn-terms-of-service/">MathJax CDN Terms of Service</a>.',
 			"<input type='checkbox' name='kblog_mathjax_use_cdn' id='use_cdn' value='1' $use_cdn/>",
 			'use_cdn'
 		);

--- a/mathjax-latex-admin.php
+++ b/mathjax-latex-admin.php
@@ -57,7 +57,7 @@ class MathJax_Latex_Admin {
 
 		// save options if this is a valid post
 		if ( isset( $_POST['kblog_mathjax_latex_save_field'] ) && // input var okay
-			wp_verify_nonce( sanitize_text_field( $_POST['kblog_mathjax_latex_save_field'] ), 'kblog_mathjax_latex_save_action' ) // input var okay
+			wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['kblog_mathjax_latex_save_field'] ) ), 'kblog_mathjax_latex_save_action' ) // input var okay
 		) {
 			echo "<div class='updated settings-error' id='etting-error-settings_updated'><p><strong>Settings saved.</strong></p></div>\n";
 			$this->admin_save();
@@ -156,9 +156,9 @@ EOT;
 		update_option( 'kblog_mathjax_force_load', array_key_exists( 'kblog_mathjax_force_load', $_POST ) ); // input var okay
 
 		if ( array_key_exists( 'kblog_mathjax_latex_inline', $_POST ) && isset( $_POST['kblog_mathjax_latex_inline'] ) && // input var okay
-			in_array( sanitize_text_field( $_POST['kblog_mathjax_latex_inline'] ), array( 'inline', 'display' ) ) // input var okay
+			in_array( sanitize_text_field( wp_unslash( $_POST['kblog_mathjax_latex_inline'] ) ), array( 'inline', 'display' ), true ) // input var okay
 		) {
-			update_option( 'kblog_mathjax_latex_inline', sanitize_text_field( $_POST['kblog_mathjax_latex_inline'] ) ); // input var okay
+			update_option( 'kblog_mathjax_latex_inline', sanitize_text_field( wp_unslash( $_POST['kblog_mathjax_latex_inline'] ) ) ); // input var okay
 		}
 
 		update_option( 'kblog_mathjax_use_wplatex_syntax', array_key_exists( 'kblog_mathjax_use_wplatex_syntax', $_POST ) ); // input var okay
@@ -166,13 +166,13 @@ EOT;
 		update_option( 'kblog_mathjax_use_cdn', array_key_exists( 'kblog_mathjax_use_cdn', $_POST ) ); // input var okay
 
 		if ( array_key_exists( 'kblog_mathjax_custom_location', $_POST ) && isset( $_POST['kblog_mathjax_custom_location'] ) ) { // input var okay
-			update_option( 'kblog_mathjax_custom_location', esc_url_raw( $_POST['kblog_mathjax_custom_location'] ) ); // input var okay
+			update_option( 'kblog_mathjax_custom_location', esc_url_raw( wp_unslash( $_POST['kblog_mathjax_custom_location'] ) ) ); // input var okay
 		}
 
 		if ( array_key_exists( 'kblog_mathjax_config', $_POST ) && isset( $_POST['kblog_mathjax_config'] ) && // input var okay
-			in_array( sanitize_text_field( $_POST['kblog_mathjax_config'] ), $this->config_options() ) // input var okay
+			in_array( sanitize_text_field( wp_unslash( $_POST['kblog_mathjax_config'] ) ), $this->config_options(), true ) // input var okay
 		) {
-			update_option( 'kblog_mathjax_config', sanitize_text_field( $_POST['kblog_mathjax_config'] ) ); // input var okay
+			update_option( 'kblog_mathjax_config', sanitize_text_field( wp_unslash( $_POST['kblog_mathjax_config'] ) ) ); // input var okay
 		}
 	}
 

--- a/mathjax-latex.php
+++ b/mathjax-latex.php
@@ -232,7 +232,7 @@ class MathJax {
 	public static function filter_br_tags_on_math( $content ) {
 		return preg_replace_callback(
 			'/(<math.*>.*<\/math>)/isU',
-			function ( $matches ) {
+			function( $matches ) {
 				return str_replace( array( '<br/>', '<br />', '<br>' ) , '' , $matches[0] );
 			},
 			$content

--- a/mathjax-latex.php
+++ b/mathjax-latex.php
@@ -172,7 +172,7 @@ class MathJax {
 
 		// initialise option for existing MathJax-LaTeX users
 		if ( get_option( 'kblog_mathjax_use_cdn' ) || ! get_option( 'kblog_mathjax_custom_location' ) ) {
-			$mathjax_location = '//cdn.mathjax.org/mathjax/latest/MathJax.js';
+			$mathjax_location = 'https://cdn.mathjax.org/mathjax/latest/MathJax.js';
 		} else {
 			$mathjax_location = get_option( 'kblog_mathjax_custom_location' );
 		}

--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@
 Contributors: philliplord, sjcockell, knowledgeblog, d_swan, paulschreiber, jwenerd
 Tags: mathematics, math, latex, mathml, mathjax, science, res-comms, scholar, academic
 Requires at least: 3.0
-Tested up to: 4.0.0
-Stable tag: 1.3.3
+Tested up to: 4.3
+Stable tag: 1.3.4
 License: GPLv3
 
 This plugin enables mathjax (http://www.mathjax.org) functionality for
@@ -59,6 +59,12 @@ MathJax-LaTeX is developed on
 
 
 == Changelog ==
+
+= 1.3.4 =
+
+1. PHP code cleanup
+1. Always use https URL for MathJax library
+1. Updated "tested up to" to 4.3
 
 = 1.3.3 =
 


### PR DESCRIPTION
* strict equality (and in_array)
* whitespace fixes
* call wp_unslash() before sanitizing
* eliminate unnecessary string concatentation