### PR TITLE
Add support for configuration filter

### DIFF
--- a/mathjax-latex.php
+++ b/mathjax-latex.php
@@ -94,7 +94,6 @@ class MathJax {
 		add_shortcode( 'nomathjax', array( __CLASS__, 'nomathjax_shortcode' ) );
 		add_shortcode( 'latex', array( __CLASS__, 'latex_shortcode' ) );
 		add_action( 'wp_footer', array( __CLASS__, 'add_script' ) );
-		add_action( 'wp_footer', array( __CLASS__, 'unconditional' ) );
 
 		if ( get_option( 'kblog_mathjax_use_wplatex_syntax' ) ) {
 			add_filter( 'the_content', array( __CLASS__, 'inline_to_shortcode' ) );
@@ -125,19 +124,6 @@ class MathJax {
 		delete_option( 'kblog_mathjax_use_cdn' );
 		delete_option( 'kblog_mathjax_custom_location' );
 		delete_option( 'kblog_mathjax_config' );
-	}
-
-	public static function unconditional() {
-		echo '<!-- MathJax Latex Plugin installed';
-		if ( ! self::$add_script ) {
-			echo ': Disabled as no shortcodes on this page';
-		}
-
-		if ( self::$block_script ) {
-			echo ': Disabled by nomathjax shortcode';
-		}
-
-		echo ' -->';
 	}
 
 	public static function mathjax_shortcode( $atts, $content ) {

--- a/mathjax-latex.php
+++ b/mathjax-latex.php
@@ -96,6 +96,7 @@ class MathJax {
 		add_shortcode( 'nomathjax', array( __CLASS__, 'nomathjax_shortcode' ) );
 		add_shortcode( 'latex', array( __CLASS__, 'latex_shortcode' ) );
 		add_action( 'wp_footer', array( __CLASS__, 'add_script' ) );
+		add_filter( 'script_loader_tag', array( __CLASS__, 'script_loader_tag' ), 10, 3 );
 
 		if ( get_option( 'kblog_mathjax_use_wplatex_syntax' ) ) {
 			add_filter( 'the_content', array( __CLASS__, 'inline_to_shortcode' ) );
@@ -168,6 +169,30 @@ class MathJax {
 		$mathjax_url = $mathjax_location . '?config=' . get_option( 'kblog_mathjax_config' );
 
 		wp_enqueue_script( 'mathjax', $mathjax_url, false, MATHJAX_VERSION, false );
+
+		$mathjax_config = apply_filters( 'mathjax_config', array() );
+		if ( $mathjax_config ) {
+			wp_add_inline_script( 'mathjax', 'MathJax.Hub.Config(' . wp_json_encode( $mathjax_config ) . ');' );
+		}
+	}
+
+
+	/**
+	 * Set the script tag to have type text/x-mathjax-config
+	 *
+	 * @param string $tag    The `<script>` tag for the enqueued script.
+	 * @param string $handle The script's registered handle.
+	 * @param string $src    The script's source URL.
+	 *
+	 * @return string $tag
+	 */
+	public static function script_loader_tag( $tag, $handle = null, $src = null ) {
+		if ( 'mathjax' === $handle ) {
+			// replace the <script> tag for the inline script, but not for the <script> tag with src=""
+			return str_replace( "<script type='text/javascript'>", "<script type='text/x-mathjax-config'>", $tag );
+		}
+
+		return $tag;
 	}
 
 	public static function inline_to_shortcode( $content ) {

--- a/mathjax-latex.php
+++ b/mathjax-latex.php
@@ -156,7 +156,7 @@ class MathJax {
 
 		if ( 'inline' === $shortcode_atts['syntax'] ) {
 			return '\(' . $content . '\)';
-		} else if ( 'display' === $shortcode_atts['syntax'] ) {
+		} elseif ( 'display' === $shortcode_atts['syntax'] ) {
 			return '\[' . $content . '\]';
 		}
 	}

--- a/mathjax-latex.php
+++ b/mathjax-latex.php
@@ -2,7 +2,7 @@
 /*
  Plugin Name: MathJax-LaTeX
  Description: Transform latex equations in JavaScript using mathjax
- Version: 1.3.4
+ Version: 1.3.5
  Author: Phillip Lord, Simon Cockell, Paul Schreiber
  Author URI: http://knowledgeblog.org
 
@@ -32,7 +32,7 @@
  * along with this program. If not, see http://www.gnu.org/licenses/.
  */
 
-define( 'MATHJAX_VERSION', '1.3.4' );
+define( 'MATHJAX_VERSION', '1.3.5' );
 
 require_once( dirname( __FILE__ ) . '/mathjax-latex-admin.php' );
 

--- a/mathjax-latex.php
+++ b/mathjax-latex.php
@@ -32,6 +32,8 @@
  * along with this program. If not, see http://www.gnu.org/licenses/.
  */
 
+define( 'MATHJAX_VERSION', '1.3.4' );
+
 require_once( dirname( __FILE__ ) . '/mathjax-latex-admin.php' );
 
 class MathJax {
@@ -165,7 +167,7 @@ class MathJax {
 
 		$mathjax_url = $mathjax_location . '?config=' . get_option( 'kblog_mathjax_config' );
 
-		wp_enqueue_script( 'mathjax', $mathjax_url, false, '1.2.1', false );
+		wp_enqueue_script( 'mathjax', $mathjax_url, false, MATHJAX_VERSION, false );
 	}
 
 	public static function inline_to_shortcode( $content ) {

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@
 Contributors: philliplord, sjcockell, knowledgeblog, d_swan, paulschreiber, jwenerd
 Tags: mathematics, math, latex, mathml, mathjax, science, res-comms, scholar, academic
 Requires at least: 3.0
-Tested up to: 4.3
+Tested up to: 4.5
 Stable tag: 1.3.4
 License: GPLv3
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@
 Contributors: philliplord, sjcockell, knowledgeblog, d_swan, paulschreiber, jwenerd
 Tags: mathematics, math, latex, mathml, mathjax, science, res-comms, scholar, academic
 Requires at least: 3.0
-Tested up to: 4.5
-Stable tag: 1.3.4
+Tested up to: 4.7.3
+Stable tag: 1.3.5
 License: GPLv3
 
 This plugin enables mathjax (http://www.mathjax.org) functionality for
@@ -59,6 +59,10 @@ MathJax-LaTeX is developed on
 
 
 == Changelog ==
+
+= 1.3.5 =
+
+1. Add support for MathJax config via filter
 
 = 1.3.4 =
 


### PR DESCRIPTION
Adds `<script>` tag with MathJax config if `mathjax_config` array is populated.