### PR TITLE
Update location of MathJax CDN

### DIFF
--- a/mathjax-latex.php
+++ b/mathjax-latex.php
@@ -161,7 +161,7 @@ class MathJax {
 
 		// initialise option for existing MathJax-LaTeX users
 		if ( get_option( 'kblog_mathjax_use_cdn' ) || ! get_option( 'kblog_mathjax_custom_location' ) ) {
-			$mathjax_location = 'https://cdn.mathjax.org/mathjax/latest/MathJax.js';
+			$mathjax_location = 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js';
 		} else {
 			$mathjax_location = get_option( 'kblog_mathjax_custom_location' );
 		}


### PR DESCRIPTION
See <https://www.mathjax.org/cdn-shutting-down/>. Fixes #18.