### PR TITLE
Add null check in filter_br_tags_on_math

### DIFF
--- a/mathjax-latex.php
+++ b/mathjax-latex.php
@@ -243,13 +243,14 @@ class MathJax {
 	 * @return string without <br /> tags
 	 */
 	public static function filter_br_tags_on_math( $content ) {
-		return preg_replace_callback(
-			'/(<math.*>.*<\/math>)/isU',
-			function( $matches ) {
-				return str_replace( array( '<br/>', '<br />', '<br>' ) , '' , $matches[0] );
-			},
-			$content
-		);
+		$filteredContent = preg_replace_callback(
+            '/(<math.*>.*<\/math>)/isU',
+            function( $matches ) {
+                return str_replace( array( '<br/>', '<br />', '<br>' ) , '' , $matches[0] );
+            },
+            $content
+        );
+	    return $filteredContent === null ? $content : $filteredContent;
 	}
 
 	/**


### PR DESCRIPTION
The function `preg_replace_callback` may return a null when error happening.
I've added a null check of the filter result.
It will return original content if error happened in there.